### PR TITLE
[修复] 在小米 6.0 系统上,  开启浮窗权限后, 重启手机需要重新开启的问题

### DIFF
--- a/library/src/main/java/ezy/assist/compat/OverlayPermissionCompat.java
+++ b/library/src/main/java/ezy/assist/compat/OverlayPermissionCompat.java
@@ -149,7 +149,7 @@ public class OverlayPermissionCompat {
                 Intent intent = new Intent("miui.intent.action.APP_PERM_EDITOR");
                 intent.putExtra("extra_pkgname", context.getPackageName());
                 intent.setClassName("com.miui.securitycenter", "com.miui.permcenter.permissions.AppPermissionsEditorActivity");
-                if (!startSafely(context, intent)){
+                if (!startSafely(context, intent)) {
                     intent.setClassName("com.miui.securitycenter", "com.miui.permcenter.permissions.PermissionsEditorActivity");
                     startSafely(context, intent);
                 }
@@ -220,6 +220,8 @@ public class OverlayPermissionCompat {
         public void request(Activity activity) {
             if (RomUtil.isFlyme()) {
                 editForMeizu(activity);
+            } else if (RomUtil.isMiui()) {
+                editForMiui(activity);
             } else {
                 Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
                 intent.setData(Uri.parse("package:" + activity.getPackageName()));


### PR DESCRIPTION
测试手机 小米4 MIUI 8 6.12.8 开发版
发现问题：
开启浮窗权限后，重启手机又会需要再次开启，并且自带的安全中心里面，看到 App 并没有浮窗权限。
解决方法：
如果是 M 及以后的设备，还是用 M 以前的方法来开启浮窗权限。经测试，用 M 以前的方式开启重启没问题。
---------
这个问题目前我只在这一台手机上发现，并且我只有这一台小米 6.0，所以你可以再多测试一下。
