### PR TITLE
fix issue "startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag"

### DIFF
--- a/library/src/main/java/ezy/assist/compat/SettingsCompat.java
+++ b/library/src/main/java/ezy/assist/compat/SettingsCompat.java
@@ -73,7 +73,7 @@ public class SettingsCompat {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
             intent.setData(Uri.parse("package:" + context.getPackageName()));
-            context.startActivity(intent);
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
         }
     }
 
@@ -81,7 +81,7 @@ public class SettingsCompat {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             Intent intent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS);
             intent.setData(Uri.parse("package:" + context.getPackageName()));
-            context.startActivity(intent);
+            context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
         }
     }
 


### PR DESCRIPTION
原问题: https://github.com/hyb1996-guest/AutoJsIssueReport/issues/5597 
关键：
```
android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
at ezy.assist.compat.SettingsCompat.manageDrawOverlays(SettingsCompat.java:76)
```